### PR TITLE
Silence deprecation warning on `_lookupFactory`

### DIFF
--- a/addon/services/config.js
+++ b/addon/services/config.js
@@ -1,15 +1,15 @@
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
 
 const {
   Service,
   computed,
-  get
+  get,
+  getOwner
 } = Ember;
 
 export default Service.extend({
   __config__: computed(function() {
-    return getOwner(this)._lookupFactory('config:environment');
+    return getOwner(this).factoryFor('config:environment').class;
   }),
 
   unknownProperty(path) {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "ember-data": "^2.7.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
+    "ember-factory-for-polyfill": "1.1.1",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.1"
@@ -45,8 +46,7 @@
     "config"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6",
-    "ember-getowner-polyfill": "^1.0.0"
+    "ember-cli-babel": "^5.1.6"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "ember-data": "^2.7.0",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-factory-for-polyfill": "1.1.1",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "loader.js": "^4.0.1"
@@ -46,7 +45,8 @@
     "config"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.6"
+    "ember-cli-babel": "^5.1.6",
+    "ember-getowner-polyfill": "1.2.2"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
As per http://emberjs.com/deprecations/v2.x/#toc_migrating-from-_lookupfactory-to-factoryfor.

Also fixes #12.
